### PR TITLE
Compress .map files in production configuration

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -143,7 +143,7 @@ const productionConfig = merge([
         swDest: resolve(OUTPUT_PATH, 'sw.js'),
         exclude: [/webcomponents-(?!loader).*\.js$/]
       }),
-      new CompressionPlugin({ test: /\.js$/ }),
+      new CompressionPlugin({ test: /\.js(\.map)?$/i }),
       ...analyzeConfig
     ]
   }


### PR DESCRIPTION
Small change to compress not only .js files to .gz for express static file serving, but .map files also. The big culprits are the polyfill files. `webcomponents-bundle.js.map` is over 600kB. Compressing drops it down to ~162kB. App goes from ~3.4MB down to ~1.2MB