### PR TITLE
Add Brotli compression

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "babel-loader": "^8.0.0",
     "babel-plugin-template-html-minifier": "^2.0.1",
     "babel-preset-minify": "^0.5.0",
+    "brotli-webpack-plugin": "^1.0",
     "clean-webpack-plugin": "^0.1.19",
     "compression-webpack-plugin": "^2.0.0",
     "concurrently": "^4.0.1",

--- a/server.js
+++ b/server.js
@@ -11,7 +11,12 @@ app.get('/api/users', (req, res) => {
 });
 
 app.use(history());
-app.use(serveStatic(__dirname + '/dist/'));
+app.use(
+  serveStatic(__dirname + '/dist/', {
+    enableBrotli: true,
+    orderPreference: ['br', 'gz']
+  })
+);
 app.listen(port);
 
 console.info(`Project is running at http://localhost:${port}`);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,7 @@ const CleanWebpackPlugin = require('clean-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const CompressionPlugin = require('compression-webpack-plugin');
+const BrotliPlugin = require('brotli-webpack-plugin');
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 const { InjectManifest } = require('workbox-webpack-plugin');
 
@@ -144,6 +145,13 @@ const productionConfig = merge([
         exclude: [/webcomponents-(?!loader).*\.js$/]
       }),
       new CompressionPlugin({ test: /\.js(\.map)?$/i }),
+      new BrotliPlugin({
+        asset: '[path].br[query]',
+        test: /\.js(\.map)?$/i,
+        threshold: 20,
+        minRatio: 0.8,
+        mode: 1
+      }),
       ...analyzeConfig
     ]
   }


### PR DESCRIPTION
For static served files. Saves ~200kB on app load. This does not have the dep upgrades as those were conflicting and the rebase was too complicated for these few changes.