### PR TITLE
Add "nomodule" for transpilation scripts

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -45,7 +45,7 @@ This program is available under Apache License Version 2.0, available at https:/
     <meta name="msapplication-tap-highlight" content="no">
 
     <script>if (!window.customElements) { document.write('<!--'); }</script>
-    <script src="./vendor/custom-elements-es5-adapter.js"></script>
+    <script nomodule src="./vendor/custom-elements-es5-adapter.js"></script>
     <!--! DO NOT REMOVE THIS COMMENT, WE NEED ITS CLOSING MARKER -->
 
     <script>
@@ -90,7 +90,7 @@ This program is available under Apache License Version 2.0, available at https:/
       Vaadin App
     </starter-app>
     <!-- Load the external helpers to run the code transpiled to ES5 -->
-    <script src="./vendor/babel-helpers.min.js"></script>
+    <script nomodule src="./vendor/babel-helpers.min.js"></script>
     <!-- Load webcomponents-loader.js to check and load any polyfills your browser needs -->
     <script src="./vendor/webcomponents-loader.js"></script>
   </body>


### PR DESCRIPTION
This should be safe to do because you are only doing a module/no module build. This means that all components must be modules as a "modern" browser will attempt to parse it that way due to `<script type="module">`.

One thing I noticed is
https://github.com/web-padawan/polymer3-webpack-starter/blob/face1cef24ca8938c07b8fe192028963348846e9/webpack.config.prod.js#L174-L179
This basically means that _no_ babel helpers will be used other than `import` and `babel-plugin-template-html-minifier`. This might be an issue with Edge as it _does_ natively support modules, but doesn't support everything in `utils/helper-whitelist.js` such as `objectSpread`. Not sure if there's a good way to work around that.

FWIW, I do like the idea of splitting on modules as I now don't have to do browser sniffing and differential serving.