### PR TITLE
Make app CSP safe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 dist/
 node_modules/
-src/vendor/
+src/vendor/babel-helpers.min.js

--- a/src/index.html
+++ b/src/index.html
@@ -44,15 +44,6 @@ This program is available under Apache License Version 2.0, available at https:/
     <meta name="msapplication-TileColor" content="#1576f3">
     <meta name="msapplication-tap-highlight" content="no">
 
-    <script>
-      // Load and register pre-caching Service Worker
-      if ('serviceWorker' in navigator) {
-        window.addEventListener('load', function() {
-          navigator.serviceWorker.register('sw.js');
-        });
-      }
-    </script>
-
     <!-- Add any global styles for body, document, etc. -->
     <style>
       body {
@@ -85,6 +76,8 @@ This program is available under Apache License Version 2.0, available at https:/
     <starter-app unresolved>
       Vaadin App
     </starter-app>
+    <!-- Load and register pre-caching Service Worker -->
+    <script src="./vendor/register-service-worker.min.js"></script>
     <!-- Load the external helpers to run the code transpiled to ES5 -->
     <script nomodule src="./vendor/babel-helpers.min.js"></script>
     <!-- Load webcomponents-loader.js to check and load any polyfills your browser needs -->

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -4,7 +4,6 @@
 // caching strategies, as Workbox will auto-inject that part when you build your
 // project. This is the perfect place to implement other great SW features.
 // (e.g. Web Push, etc...)
-workbox.skipWaiting();
 workbox.clientsClaim();
 workbox.precaching.suppressWarnings();
 

--- a/src/vendor/register-service-worker.min.js
+++ b/src/vendor/register-service-worker.min.js
@@ -1,0 +1,6 @@
+// Load and register pre-caching Service Worker
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', function() {
+    navigator.serviceWorker.register('../sw.js');
+  });
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,17 +32,16 @@ const polyfills = [
     from: resolve(`${webcomponentsjs}/bundles/*.{js,map}`),
     to: join(OUTPUT_PATH, 'vendor', 'bundles'),
     flatten: true
-  },
-  {
-    from: resolve(`${webcomponentsjs}/custom-elements-es5-adapter.js`),
-    to: join(OUTPUT_PATH, 'vendor'),
-    flatten: true
   }
 ];
 
 const helpers = [
   {
     from: resolve('./src/vendor/babel-helpers.min.js'),
+    to: join(OUTPUT_PATH, 'vendor')
+  },
+  {
+    from: resolve('./src/vendor/register-service-worker.min.js'),
     to: join(OUTPUT_PATH, 'vendor')
   }
 ];


### PR DESCRIPTION
-  Making a file for service worker loader;
- Remove unneeded call to `custom-elements-es5-adapter` as it's no longer used in app
- Remove workbox.skipWaiting from ServiceWorker. When used with something like webpack that has lazy loaded, hashed fragments, [it's recommended to not include this](https://developers.google.com/web/tools/workbox/modules/workbox-sw#skip_waiting_and_clients_claim). FWIW, I have encountered the errors that this can lead to if I quickly click to the next page before the SW has cached it.