### PR TITLE
Use babel-plugin-bundled-import-meta to support import.meta.url

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ a module bundler. The optimizations like code splitting, minifying JavaScript an
 - Up-to-date [Babel 7](https://github.com/babel/babel) verified to work nice with Custom Elements
 - Modern build for evergreen browsers using [BabelMultiTargetPlugin](https://github.com/DanielSchaffer/webpack-babel-multi-target-plugin)
 - Minification of JavaScript using [Terser](https://github.com/terser-js/terser) supporting ES2015+
-- Minification of HTML and CSS in [tagged template literals](https://github.com/goto-bus-stop/babel-plugin-template-html-minifier)
+- Minification of HTML and CSS in [tagged template literals](https://github.com/cfware/babel-plugin-template-html-minifier)
 - Automatic service worker generation using [Workbox](https://github.com/GoogleChrome/workbox)
 - Automatic [bundle analysis](https://github.com/webpack-contrib/webpack-bundle-analyzer) and report generation
 - Web server using [express](https://github.com/expressjs/express) and [History API](https://github.com/bripkens/connect-history-api-fallback) middleware

--- a/README.md
+++ b/README.md
@@ -72,4 +72,6 @@ npm run build:analyze
 
 ## Known limitations
 
-- Using `import.meta` suggested by Polymer docs is not supported, see [webpack/webpack#6719](https://github.com/webpack/webpack/issues/6719)
+- Using `import.meta` suggested by Polymer docs is not supported out of the box, see [webpack/webpack#6719](https://github.com/webpack/webpack/issues/6719).
+  Support can be added with [babel-plugin-bundled-import-meta](https://github.com/cfware/babel-plugin-bundled-import-meta) or
+  webpack loader [import-meta-url-loader](https://github.com/open-wc/open-wc/blob/master/packages/webpack/loaders/import-meta-url-loader.js)


### PR DESCRIPTION
This adds basic support for `import.meta.url`.  As configured this will only work when `src/**.js` uses `import.meta.url`.  I'm unsure of the webpack build process for handling additional assets in node_modules.  Specifically if node_modules/some-module/index.js uses: `new URL('index.json', import.meta.url).toString()`, the bundle would need a mapping.  So you might modify webpack.config.js:
```js
            [
              require('babel-plugin-bundled-import-meta'),
              {
                bundleDir: 'src',
                importStyle: 'umd'
                mappings: {
                  'node_modules': './node_modules'
                }
              }
            ],
```
Then copy `node_modules/some-module/index.json` or even `node_modules/some-module/**` to `dist/node_modules/some-module/`.  This way the bundled script would rewrite `import.meta.url` to the correct URL of the script such that it can be used as the `base` argument to `new URL(url, base)`.  In rollup I get a list of all node_modules that were imported to the bundle, then copy the complete directory to make sure any assets loaded via import.meta.url can be found.

I tested this by adding `console.log(import.meta.url);` to src/app/starter-app.js, verified that it printed `http://localhost:8000/app/starter-app.js`.  I've only tested this with in Firefox 64, I don't have access to legacy browsers to test the non-module build.