### PR TITLE
Remove custom elements adapter; remove problematic workbox function

### DIFF
--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -4,7 +4,6 @@
 // caching strategies, as Workbox will auto-inject that part when you build your
 // project. This is the perfect place to implement other great SW features.
 // (e.g. Web Push, etc...)
-workbox.skipWaiting();
 workbox.clientsClaim();
 workbox.precaching.suppressWarnings();
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,11 +32,6 @@ const polyfills = [
     from: resolve(`${webcomponentsjs}/bundles/*.{js,map}`),
     to: join(OUTPUT_PATH, 'vendor', 'bundles'),
     flatten: true
-  },
-  {
-    from: resolve(`${webcomponentsjs}/custom-elements-es5-adapter.js`),
-    to: join(OUTPUT_PATH, 'vendor'),
-    flatten: true
   }
 ];
 


### PR DESCRIPTION
- Remove unneeded call to custom-elements-es5-adapter as it's no longer used in app
- Remove `workbox.skipWaiting()` from ServiceWorker. When used with something like webpack that has lazy loaded, hashed fragments, [it's recommended to not include this](https://developers.google.com/web/tools/workbox/modules/workbox-sw#skip_waiting_and_clients_claim). FWIW, I have encountered the errors that this can lead to if I quickly click to the next page before the SW has cached it.