### PR TITLE
Workbox config clean

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "terser-webpack-plugin": "^1.2.1",
     "uglify-template-string-loader": "^1.1.0",
     "webpack": "^4.28.4",
-    "webpack-babel-multi-target-plugin": "2.1.0-alpha.1",
+    "webpack-babel-multi-target-plugin": "^2.1.0-alpha.5",
     "webpack-bundle-analyzer": "^3.0.3",
     "webpack-cli": "^3.2.1",
     "webpack-dev-server": "^3.1.10",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "terser-webpack-plugin": "^1.2.1",
     "uglify-template-string-loader": "^1.1.0",
     "webpack": "^4.28.4",
-    "webpack-babel-multi-target-plugin": "^2.1.0-alpha.5",
+    "webpack-babel-multi-target-plugin": "2.1.0-alpha.5",
     "webpack-bundle-analyzer": "^3.0.3",
     "webpack-cli": "^3.2.1",
     "webpack-dev-server": "^3.1.10",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -130,7 +130,7 @@ const commonConfig = merge([
         ],
 
         // Fix for `nomodule` attribute to work correctly in Safari 10.1
-        safari10NoModuleFix: true,
+        safari10NoModuleFix: 'inline-data-base64',
 
         // Target browsers with and without ES modules support
         targets: {
@@ -211,7 +211,10 @@ const productionConfig = merge([
       new InjectManifest({
         swSrc: resolve('src', 'service-worker.js'),
         swDest: resolve(OUTPUT_PATH, 'sw.js'),
-        exclude: [/webcomponents-(?!loader).*\.js$/]
+        exclude: [
+          /.*\/webcomponents-(?!loader).*\.js(\.map)?$/,
+          /.*\.es5\..*\.js$/
+        ]
       }),
       new CompressionPlugin({ test: /\.js(\.map)?$/i }),
       new BrotliPlugin({


### PR DESCRIPTION
Fixes #26.

• Fix InjectManifest config: don't precache webcomponent bundles; don't precache ES5 modules
• Specify safari10NoModuleFix type

Edit: This brings the total weight from about 1MB to about 377k for ESM browsers.