### PR TITLE
Add back sourcemaps and parallel processing to TerserPlugin

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -192,7 +192,9 @@ const productionConfig = merge([
             output: {
               comments: false
             }
-          }
+          },
+          sourceMap: true,
+          parallel: true
         })
       ]
     },
@@ -212,7 +214,8 @@ const productionConfig = merge([
         swSrc: resolve('src', 'service-worker.js'),
         swDest: resolve(OUTPUT_PATH, 'sw.js'),
         exclude: [
-          /.*\/webcomponents-(?!loader).*\.js(\.map)?$/,
+          /.*\.map$/,
+          /.*\/webcomponents-(?!loader).*\.js$/,
           /.*\.es5\..*\.js$/
         ]
       }),


### PR DESCRIPTION
• Add back in non-specific TerserPlugin options
• Never pre-cache .map files

I haven't looked back into the other specific options that were mentioned in #28. They might squeeze the code down, but who knows what might break when users start adding their own code. Not pre-caching `.map` files makes the page quite a bit lighter for production.

Anything outstanding you are thinking of adding before this repo goes into "maintenance" mode? It's a pretty complete little skeleton right now unless you were planning on doing an all `lit-element` version.