### PR TITLE
Update to use vaadin-app-layout component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -887,18 +887,6 @@
         "@hapi/hoek": "6.x.x"
       }
     },
-    "@polymer/app-layout": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@polymer/app-layout/-/app-layout-3.0.2.tgz",
-      "integrity": "sha512-qKcQHj72uGxGoetjnNQ7pg4F6Da4U5jKBzZy0VRmDuZMUPDmtIqHaIgC5K6B4y+xUag0gkV9ce72Q3hNaK9y+g==",
-      "requires": {
-        "@polymer/iron-flex-layout": "^3.0.0-pre.26",
-        "@polymer/iron-media-query": "^3.0.0-pre.26",
-        "@polymer/iron-resizable-behavior": "^3.0.0-pre.26",
-        "@polymer/iron-scroll-target-behavior": "^3.0.0-pre.26",
-        "@polymer/polymer": "^3.0.0"
-      }
-    },
     "@polymer/iron-a11y-announcer": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@polymer/iron-a11y-announcer/-/iron-a11y-announcer-3.0.2.tgz",
@@ -1111,6 +1099,19 @@
       "requires": {
         "@vaadin/vaadin-usage-statistics": "^2.0.1",
         "path-to-regexp": "2.2.1"
+      }
+    },
+    "@vaadin/vaadin-app-layout": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-app-layout/-/vaadin-app-layout-2.0.0.tgz",
+      "integrity": "sha512-g67Z1jb0jXaEYcaJpVbZYoWa9f2xSm5biZlUuAPLQs2lUZN6HTNN68/toPWjGcE1Pb6ZYXn23ielc03U993jBA==",
+      "requires": {
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/vaadin-button": "^2.1.0",
+        "@vaadin/vaadin-element-mixin": "^2.0.0",
+        "@vaadin/vaadin-lumo-styles": "^1.1.0",
+        "@vaadin/vaadin-material-styles": "^1.1.0",
+        "@vaadin/vaadin-themable-mixin": "^1.2.0"
       }
     },
     "@vaadin/vaadin-button": {

--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/web-padawan/polymer3-webpack-starter.git"
   },
   "dependencies": {
-    "@polymer/app-layout": "^3.0.2",
     "@polymer/iron-ajax": "^3.0.1",
     "@polymer/iron-form": "^3.0.1",
     "@polymer/iron-icon": "^3.0.1",
     "@polymer/polymer": "^3.2.0",
     "@vaadin/router": "^1.2.1",
+    "@vaadin/vaadin-app-layout": "^2.0.0",
     "@vaadin/vaadin-button": "^2.2.0",
     "@vaadin/vaadin-checkbox": "^2.2.10",
     "@vaadin/vaadin-combo-box": "^5.0.3",

--- a/src/app/starter-app.js
+++ b/src/app/starter-app.js
@@ -30,8 +30,8 @@ class StarterApp extends PolymerElement {
           background: var(--lumo-primary-color);
         }
         vaadin-drawer-toggle {
-          width: 36px;
-          height: 36px;
+          width: var(--lumo-size-m);
+          height: var(--lumo-size-m);
           padding: 0;
           margin: var(--lumo-space-m);
           background: var(--lumo-tint);

--- a/src/app/starter-app.js
+++ b/src/app/starter-app.js
@@ -32,7 +32,7 @@ class StarterApp extends PolymerElement {
         vaadin-drawer-toggle {
           width: var(--lumo-size-m);
           height: var(--lumo-size-m);
-          margin: var(--lumo-space-m);
+          margin: 0 var(--lumo-space-m);
           padding: 0;
           background: var(--lumo-tint);
         }
@@ -53,8 +53,9 @@ class StarterApp extends PolymerElement {
           text-decoration: none;
         }
         [main-title] {
+          padding: var(--lumo-space-m) 0;
           font-size: var(--lumo-font-size-xl);
-          line-height: var(--lumo-line-height);
+          line-height: var(--lumo-line-height-m);
           font-weight: 400;
         }
       </style>

--- a/src/app/starter-app.js
+++ b/src/app/starter-app.js
@@ -5,7 +5,6 @@ import '@vaadin/vaadin-app-layout/vaadin-app-layout.js';
 import '@vaadin/vaadin-app-layout/vaadin-drawer-toggle.js';
 import '@vaadin/vaadin-item/vaadin-item.js';
 import '@vaadin/vaadin-list-box/vaadin-list-box.js';
-import '@vaadin/vaadin-lumo-styles/icons.js';
 import '../styles/shared-styles.js';
 import { EMPLOYEE_LIST, NEW_EMPLOYEE } from '../routes/urls';
 import { onLocationChanged } from '../routes/utils';

--- a/src/app/starter-app.js
+++ b/src/app/starter-app.js
@@ -30,7 +30,6 @@ class StarterApp extends PolymerElement {
           background: var(--lumo-primary-color);
         }
         vaadin-drawer-toggle {
-          display: flex;
           width: 36px;
           height: 36px;
           padding: 0;

--- a/src/app/starter-app.js
+++ b/src/app/starter-app.js
@@ -32,8 +32,8 @@ class StarterApp extends PolymerElement {
         vaadin-drawer-toggle {
           width: var(--lumo-size-m);
           height: var(--lumo-size-m);
-          padding: 0;
           margin: var(--lumo-space-m);
+          padding: 0;
           background: var(--lumo-tint);
         }
         vaadin-item {

--- a/src/app/starter-app.js
+++ b/src/app/starter-app.js
@@ -1,12 +1,8 @@
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { setPassiveTouchGestures } from '@polymer/polymer/lib/utils/settings.js';
-import '@polymer/app-layout/app-drawer/app-drawer.js';
-import '@polymer/app-layout/app-drawer-layout/app-drawer-layout.js';
-import '@polymer/app-layout/app-header/app-header.js';
-import '@polymer/app-layout/app-header-layout/app-header-layout.js';
-import '@polymer/app-layout/app-toolbar/app-toolbar.js';
-import '@vaadin/vaadin-button/vaadin-button.js';
+import '@vaadin/vaadin-app-layout/vaadin-app-layout.js';
+import '@vaadin/vaadin-app-layout/vaadin-drawer-toggle.js';
 import '@vaadin/vaadin-item/vaadin-item.js';
 import '@vaadin/vaadin-list-box/vaadin-list-box.js';
 import '@vaadin/vaadin-lumo-styles/icons.js';
@@ -27,16 +23,27 @@ class StarterApp extends PolymerElement {
         :host {
           display: block;
         }
-        app-header {
+        nav {
+          width: 100%;
+          display: flex;
+          align-items: center;
           color: var(--lumo-base-color);
           background: var(--lumo-primary-color);
         }
-        vaadin-button {
-          margin-right: var(--lumo-space-m);
+        vaadin-drawer-toggle {
+          display: flex;
+          width: 36px;
+          height: 36px;
+          padding: 0;
+          margin: var(--lumo-space-m);
           background: var(--lumo-tint);
         }
         vaadin-item {
           padding: 0;
+        }
+        h3 {
+          padding: 0 16px;
+          font-weight: 400;
         }
         a {
           display: block;
@@ -47,12 +54,25 @@ class StarterApp extends PolymerElement {
         a:hover {
           text-decoration: none;
         }
+        [main-title] {
+          font-size: var(--lumo-font-size-xl);
+          line-height: var(--lumo-line-height);
+          font-weight: 400;
+        }
       </style>
 
-      <app-drawer-layout fullbleed narrow="{{narrow}}">
-        <!-- Drawer content -->
-        <app-drawer slot="drawer" swipe-open="[[narrow]]">
-          <app-toolbar>Menu</app-toolbar>
+      <vaadin-app-layout>
+        <nav slot="navbar">
+          <aside>
+            <vaadin-drawer-toggle></vaadin-drawer-toggle>
+          </aside>
+          <div main-title>
+            <slot></slot>
+          </div>
+        </nav>
+
+        <section slot="drawer">
+          <h3>Menu</h3>
           <vaadin-list-box selected="{{selected}}" aria-controls="mainContent">
             <vaadin-item>
               <a href="/employee-list">Employee list</a>
@@ -61,25 +81,12 @@ class StarterApp extends PolymerElement {
               <a href="/employee-new">New employee</a>
             </vaadin-item>
           </vaadin-list-box>
-        </app-drawer>
+        </section>
 
-        <!-- Main content -->
-        <app-header-layout>
-          <app-header slot="header">
-            <app-toolbar>
-              <vaadin-button theme="icon" hidden$="[[!narrow]]" aria-label="Toggle menu" drawer-toggle>
-                <iron-icon icon="lumo:menu"></iron-icon>
-              </vaadin-button>
-              <div main-title>
-                <slot></slot>
-              </div>
-            </app-toolbar>
-          </app-header>
-          <main aria-live="polite" id="mainContent">
-            <!-- view content -->
-          </main>
-        </app-header-layout>
-      </app-drawer-layout>
+        <main aria-live="polite" id="mainContent">
+          <!-- view content -->
+        </main>
+      </vaadin-app-layout>
     `;
   }
 

--- a/src/app/starter-app.js
+++ b/src/app/starter-app.js
@@ -40,7 +40,7 @@ class StarterApp extends PolymerElement {
           padding: 0;
         }
         h3 {
-          padding: 0 16px;
+          padding: 0 var(--lumo-space-m);
           font-weight: 400;
         }
         a {

--- a/src/app/starter-app.js
+++ b/src/app/starter-app.js
@@ -70,6 +70,7 @@ class StarterApp extends PolymerElement {
           </div>
         </nav>
 
+        <!-- Drawer content -->
         <section slot="drawer">
           <h3>Menu</h3>
           <vaadin-list-box selected="{{selected}}" aria-controls="mainContent">
@@ -82,6 +83,7 @@ class StarterApp extends PolymerElement {
           </vaadin-list-box>
         </section>
 
+        <!-- Main content -->
         <main aria-live="polite" id="mainContent">
           <!-- view content -->
         </main>

--- a/src/index.html
+++ b/src/index.html
@@ -68,7 +68,7 @@ This program is available under Apache License Version 2.0, available at https:/
         background: hsl(214, 90%, 52%);
         padding: 16px 16px 16px 68px;
         font-size: 22px;
-        line-height: 1.675;
+        line-height: 1.625;
         font-weight: 400;
         font-family: -apple-system, BlinkMacSystemFont, "Roboto", "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
         -webkit-font-smoothing: antialiased;

--- a/src/index.html
+++ b/src/index.html
@@ -66,18 +66,12 @@ This program is available under Apache License Version 2.0, available at https:/
         display: block;
         color: #fff;
         background: hsl(214, 90%, 52%);
-        padding: 16px;
-        font-size: 20px;
-        line-height: 1.625;
+        padding: 16px 16px 16px 68px;
+        font-size: 22px;
+        line-height: 1.675;
         font-weight: 400;
         font-family: -apple-system, BlinkMacSystemFont, "Roboto", "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
         -webkit-font-smoothing: antialiased;
-      }
-
-      @media (min-width: 640px) {
-        starter-app[unresolved] {
-          margin-left: 256px;
-        }
       }
     </style>
   </head>

--- a/src/styles/shared-styles.js
+++ b/src/styles/shared-styles.js
@@ -3,24 +3,39 @@ import '@vaadin/vaadin-lumo-styles/sizing.js';
 import '@vaadin/vaadin-lumo-styles/spacing.js';
 import '@vaadin/vaadin-lumo-styles/style.js';
 import '@vaadin/vaadin-lumo-styles/typography.js';
+import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 
-const $template = document.createElement('template');
-
-$template.innerHTML = `<dom-module id="shared-styles">
-  <template>
-    <style include="lumo-color lumo-typography">
-      h2 {
-        margin: var(--lumo-space-m) 0;
-      }
-      .card {
-        margin: var(--lumo-space-m);
-        padding: var(--lumo-space-m);
-        border-radius: var(--lumo-border-radius);
-        background: var(--lumo-base-color);
-        box-shadow: var(--lumo-box-shadow-s);
-      }
-    </style>
-  </template>
-</dom-module>`;
+const $template = html`
+  <dom-module id="shared-styles">
+    <template>
+      <style include="lumo-color lumo-typography">
+        h2 {
+          margin: var(--lumo-space-m) 0;
+        }
+        .card {
+          margin: var(--lumo-space-m);
+          padding: var(--lumo-space-m);
+          border-radius: var(--lumo-border-radius);
+          background: var(--lumo-base-color);
+          box-shadow: var(--lumo-box-shadow-s);
+        }
+      </style>
+    </template>
+  </dom-module>
+`;
 
 document.head.appendChild($template.content);
+
+const $layout = html`
+  <dom-module id="layout-styles" theme-for="vaadin-app-layout">
+    <template>
+      <style>
+        [part='drawer'] {
+          background: var(--lumo-base-color);
+        }
+      </style>
+    </template>
+  </dom-module>
+`;
+
+document.head.appendChild($layout.content);


### PR DESCRIPTION
The new version of `vaadin-app-layout` introduces a drawer functionality and it is a free component.

Using it instead of `@polymer/app-layout` reduces `main` bundle from 50.9 KB to 47.3 KB (minified & gzipped with brotli enabled). This should be quite an improvement for small projects.