### PR TITLE
Reorganise CSS: extract layout styles and helpers

### DIFF
--- a/src/app/starter-app.js
+++ b/src/app/starter-app.js
@@ -5,6 +5,7 @@ import '@vaadin/vaadin-app-layout/vaadin-app-layout.js';
 import '@vaadin/vaadin-app-layout/vaadin-drawer-toggle.js';
 import '@vaadin/vaadin-item/vaadin-item.js';
 import '@vaadin/vaadin-list-box/vaadin-list-box.js';
+import '../styles/layout-styles.js';
 import '../styles/shared-styles.js';
 import { EMPLOYEE_LIST, NEW_EMPLOYEE } from '../routes/urls';
 import { onLocationChanged } from '../routes/utils';
@@ -21,20 +22,6 @@ class StarterApp extends PolymerElement {
       <style include="shared-styles">
         :host {
           display: block;
-        }
-        nav {
-          width: 100%;
-          display: flex;
-          align-items: center;
-          color: var(--lumo-base-color);
-          background: var(--lumo-primary-color);
-        }
-        vaadin-drawer-toggle {
-          width: var(--lumo-size-m);
-          height: var(--lumo-size-m);
-          margin: 0 var(--lumo-space-m);
-          padding: 0;
-          background: var(--lumo-tint);
         }
         vaadin-item {
           padding: 0;

--- a/src/styles/layout-styles.js
+++ b/src/styles/layout-styles.js
@@ -1,0 +1,41 @@
+import '@vaadin/vaadin-lumo-styles/color.js';
+import '@vaadin/vaadin-lumo-styles/sizing.js';
+import '@vaadin/vaadin-lumo-styles/spacing.js';
+import { html } from '@polymer/polymer/lib/utils/html-tag.js';
+import { inject } from './style-utils.js';
+
+inject(html`
+  <dom-module id="layout-styles" theme-for="vaadin-app-layout">
+    <template>
+      <style>
+        [part='drawer'] {
+          background: var(--lumo-base-color);
+        }
+
+        [part='navbar'] ::slotted([slot='navbar']) {
+          width: 100%;
+          display: flex;
+          align-items: center;
+          color: var(--lumo-base-color);
+          background: var(--lumo-primary-color);
+        }
+      </style>
+    </template>
+  </dom-module>
+`);
+
+inject(html`
+  <dom-module id="drawer-styles" theme-for="vaadin-drawer-toggle">
+    <template>
+      <style>
+        :host {
+          width: var(--lumo-size-m);
+          height: var(--lumo-size-m);
+          margin: 0 var(--lumo-space-m);
+          padding: 0;
+          background: var(--lumo-tint);
+        }
+      </style>
+    </template>
+  </dom-module>
+`);

--- a/src/styles/shared-styles.js
+++ b/src/styles/shared-styles.js
@@ -4,8 +4,9 @@ import '@vaadin/vaadin-lumo-styles/spacing.js';
 import '@vaadin/vaadin-lumo-styles/style.js';
 import '@vaadin/vaadin-lumo-styles/typography.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
+import { inject } from './style-utils.js';
 
-const $template = html`
+inject(html`
   <dom-module id="shared-styles">
     <template>
       <style include="lumo-color lumo-typography">
@@ -22,20 +23,4 @@ const $template = html`
       </style>
     </template>
   </dom-module>
-`;
-
-document.head.appendChild($template.content);
-
-const $layout = html`
-  <dom-module id="layout-styles" theme-for="vaadin-app-layout">
-    <template>
-      <style>
-        [part='drawer'] {
-          background: var(--lumo-base-color);
-        }
-      </style>
-    </template>
-  </dom-module>
-`;
-
-document.head.appendChild($layout.content);
+`);

--- a/src/styles/style-utils.js
+++ b/src/styles/style-utils.js
@@ -1,0 +1,1 @@
+export const inject = template => document.head.appendChild(template.content);


### PR DESCRIPTION
This PR does not bring any difference in styles, only changes how they are structured:

1. All the `vaadin-app-layout` styles extracted into separate file,

2. Updated `nav` styles to emphasise it is slotted into `[part="navbar"]`,

3. Added `inject` helper to append content of `template` elements.